### PR TITLE
Remove `noAssert` argument

### DIFF
--- a/buffer-more-ints-tests.js
+++ b/buffer-more-ints-tests.js
@@ -50,11 +50,11 @@ function xint_case(xint) {
         }
 
         var buf2 = scrub(new Buffer(len));
-        buf2[writeBE](len, val, -1, true);
+        buf2[writeBE](len, val, -1);
         assert.equal(buf2.slice(0, len-1).toString("hex"),
                      buf.slice(1, len).toString("hex"));
         scrub(buf2);
-        buf2[writeBE](len, val, 1, true);
+        buf2[writeBE](len, val, 1);
         assert.equal(buf2.slice(1, len).toString("hex"),
                      buf.slice(0, len-1).toString("hex"));
 
@@ -67,11 +67,11 @@ function xint_case(xint) {
         }
 
         scrub(buf2);
-        buf2[writeLE](len, val, -1, true);
+        buf2[writeLE](len, val, -1);
         assert.equal(buf2.slice(0, len-1).toString("hex"),
                      buf.slice(1, len).toString("hex"));
         scrub(buf2);
-        buf2[writeLE](len, val, 1, true);
+        buf2[writeLE](len, val, 1);
         assert.equal(buf2.slice(1, len).toString("hex"),
                      buf.slice(0, len-1).toString("hex"));
 
@@ -84,12 +84,12 @@ function xint_case(xint) {
 
         // Test noAssert reads that stray off the ends of the buffer.
         var expect = h2b("00"+hex)[readBE](len, 0);
-        assert.equal(h2b(hex)[readBE](len, -1, true), expect);
-        assert.equals(reverse(h2b(hex))[readLE](len, 1, true), expect);
+        assert.equal(h2b(hex)[readBE](len, -1), expect);
+        assert.equals(reverse(h2b(hex))[readLE](len, 1), expect);
 
         expect = h2b(hex+"00")[readBE](len, 1);
-        assert.equal(h2b(hex)[readBE](len, 1, true), expect);
-        assert.equal(reverse(h2b(hex))[readLE](len, -1, true), expect);
+        assert.equal(h2b(hex)[readBE](len, 1), expect);
+        assert.equal(reverse(h2b(hex))[readLE](len, -1), expect);
     };
 }
 

--- a/buffer-more-ints.js
+++ b/buffer-more-ints.js
@@ -23,24 +23,20 @@ module.exports.assertContiguousInt = assertContiguousInt;
 // Fill in the regular procedures
 ['UInt', 'Int'].forEach(function (sign) {
   var suffix = sign + '8';
-  module.exports['read' + suffix] =
-    Buffer.prototype['read' + suffix].call;
-  module.exports['write' + suffix] =
-    Buffer.prototype['write' + suffix].call;
-  
+  module.exports['read' + suffix] = Buffer.prototype['read' + suffix].call;
+  module.exports['write' + suffix] = Buffer.prototype['write' + suffix].call;
+
   ['16', '32'].forEach(function (size) {
     ['LE', 'BE'].forEach(function (endian) {
       var suffix = sign + size + endian;
       var read = Buffer.prototype['read' + suffix];
-      module.exports['read' + suffix] =
-        function (buf, offset, noAssert) {
-          return read.call(buf, offset, noAssert);
-        };
+      module.exports['read' + suffix] = function (buf, offset) {
+        return read.call(buf, offset);
+      };
       var write = Buffer.prototype['write' + suffix];
-      module.exports['write' + suffix] =
-        function (buf, val, offset, noAssert) {
-          return write.call(buf, val, offset, noAssert);
-        };
+      module.exports['write' + suffix] = function (buf, val, offset) {
+        return write.call(buf, val, offset);
+      };
     });
   });
 });
@@ -50,70 +46,50 @@ function check_int(val, min, max) {
     assert.ok(typeof(val) == 'number' && val >= min && val <= max && Math.floor(val) === val, "not a number in the required range");
 }
 
-function readUInt24BE(buf, offset, noAssert) {
-  return buf.readUInt8(offset, noAssert) << 16 | buf.readUInt16BE(offset + 1, noAssert);
+function readUInt24BE(buf, offset) {
+  return buf.readUInt8(offset) << 16 | buf.readUInt16BE(offset + 1);
 }
 module.exports.readUInt24BE = readUInt24BE;
 
-function writeUInt24BE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, 0, 0xffffff);
-        assert.ok(offset + 3 <= buf.length, "attempt to write beyond end of buffer");
-    }
-
-    buf.writeUInt8(val >>> 16, offset, noAssert);
-    buf.writeUInt16BE(val & 0xffff, offset + 1, noAssert);
+function writeUInt24BE(buf, val, offset) {
+    buf.writeUintBE(val, offset, 3);
 }
 module.exports.writeUInt24BE = writeUInt24BE;
 
-function readUInt40BE(buf, offset, noAssert) {
-    return (buf.readUInt8(offset, noAssert) || 0) * SHIFT_LEFT_32 + buf.readUInt32BE(offset + 1, noAssert);
+function readUInt40BE(buf, offset) {
+    return buf.readUIntBE(offset, 5);
 }
 module.exports.readUInt40BE = readUInt40BE;
 
-function writeUInt40BE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, 0, 0xffffffffff);
-        assert.ok(offset + 5 <= buf.length, "attempt to write beyond end of buffer");
-    }
-
-    buf.writeUInt8(Math.floor(val * SHIFT_RIGHT_32), offset, noAssert);
-    buf.writeInt32BE(val & -1, offset + 1, noAssert);
+function writeUInt40BE(buf, val, offset) {
+    buf.writeIntBE(val, offset, 5);
 }
 module.exports.writeUInt40BE = writeUInt40BE;
 
-function readUInt48BE(buf, offset, noAssert) {
-    return buf.readUInt16BE(offset, noAssert) * SHIFT_LEFT_32 + buf.readUInt32BE(offset + 2, noAssert);
+function readUInt48BE(buf, offset) {
+    return buf.readUIntBE(offset, 6);
 }
 module.exports.readUInt48BE = readUInt48BE;
 
-function writeUInt48BE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, 0, 0xffffffffffff);
-        assert.ok(offset + 6 <= buf.length, "attempt to write beyond end of buffer");
-    }
-
-    buf.writeUInt16BE(Math.floor(val * SHIFT_RIGHT_32), offset, noAssert);
-    buf.writeInt32BE(val & -1, offset + 2, noAssert);
+function writeUInt48BE(buf, val, offset) {
+    buf.writeIntBE(val, offset, 6);
 }
 module.exports.writeUInt48BE = writeUInt48BE;
 
-function readUInt56BE(buf, offset, noAssert) {
-    return ((buf.readUInt8(offset, noAssert) || 0) << 16 | buf.readUInt16BE(offset + 1, noAssert)) * SHIFT_LEFT_32 + buf.readUInt32BE(offset + 3, noAssert);
+function readUInt56BE(buf, offset) {
+    return ((buf.readUInt8(offset) || 0) << 16 | buf.readUInt16BE(offset + 1)) * SHIFT_LEFT_32 + buf.readUInt32BE(offset + 3);
 }
 module.exports.readUInt56BE = readUInt56BE;
 
-function writeUInt56BE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, 0, 0xffffffffffffff);
-        assert.ok(offset + 7 <= buf.length, "attempt to write beyond end of buffer");
-    }
+function writeUInt56BE(buf, val, offset) {
+    check_int(val, 0, 0xffffffffffffff);
+    assert.ok(offset + 7 <= buf.length, "attempt to write beyond end of buffer");
 
     if (val < 0x100000000000000) {
         var hi = Math.floor(val * SHIFT_RIGHT_32);
-        buf.writeUInt8(hi >>> 16, offset, noAssert);
-        buf.writeUInt16BE(hi & 0xffff, offset + 1, noAssert);
-        buf.writeInt32BE(val & -1, offset + 3, noAssert);
+        buf.writeUInt8(hi >>> 16, offset);
+        buf.writeUInt16BE(hi & 0xffff, offset + 1);
+        buf.writeInt32BE(val & -1, offset + 3);
     } else {
         // Special case because 2^56-1 gets rounded up to 2^56
         buf[offset] = 0xff;
@@ -127,20 +103,18 @@ function writeUInt56BE(buf, val, offset, noAssert) {
 }
 module.exports.writeUInt56BE = writeUInt56BE;
 
-function readUInt64BE(buf, offset, noAssert) {
-    return buf.readUInt32BE(offset, noAssert) * SHIFT_LEFT_32 + buf.readUInt32BE(offset + 4, noAssert);
+function readUInt64BE(buf, offset) {
+    return buf.readUInt32BE(offset) * SHIFT_LEFT_32 + buf.readUInt32BE(offset + 4);
 }
 module.exports.readUInt64BE = readUInt64BE;
 
-function writeUInt64BE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, 0, 0xffffffffffffffff);
-        assert.ok(offset + 8 <= buf.length, "attempt to write beyond end of buffer");
-    }
+function writeUInt64BE(buf, val, offset) {
+    check_int(val, 0, 0xffffffffffffffff);
+    assert.ok(offset + 8 <= buf.length, "attempt to write beyond end of buffer");
 
     if (val < 0x10000000000000000) {
-        buf.writeUInt32BE(Math.floor(val * SHIFT_RIGHT_32), offset, noAssert);
-        buf.writeInt32BE(val & -1, offset + 4, noAssert);
+        buf.writeUInt32BE(Math.floor(val * SHIFT_RIGHT_32), offset);
+        buf.writeInt32BE(val & -1, offset + 4);
     } else {
         // Special case because 2^64-1 gets rounded up to 2^64
         buf[offset] = 0xff;
@@ -155,70 +129,50 @@ function writeUInt64BE(buf, val, offset, noAssert) {
 }
 module.exports.writeUInt64BE = writeUInt64BE;
 
-function readUInt24LE(buf, offset, noAssert) {
-    return buf.readUInt8(offset + 2, noAssert) << 16 | buf.readUInt16LE(offset, noAssert);
+function readUInt24LE(buf, offset) {
+    return buf.readUIntLE(offset, 3);
 }
 module.exports.readUInt24LE = readUInt24LE;
 
-function writeUInt24LE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, 0, 0xffffff);
-        assert.ok(offset + 3 <= buf.length, "attempt to write beyond end of buffer");
-    }
-
-    buf.writeUInt16LE(val & 0xffff, offset, noAssert);
-    buf.writeUInt8(val >>> 16, offset + 2, noAssert);
+function writeUInt24LE(buf, val, offset) {
+    buf.writeUIntLE(val, offset, 3);
 }
 module.exports.writeUInt24LE = writeUInt24LE;
 
-function readUInt40LE(buf, offset, noAssert) {
-    return (buf.readUInt8(offset + 4, noAssert) || 0) * SHIFT_LEFT_32 + buf.readUInt32LE(offset, noAssert);
+function readUInt40LE(buf, offset) {
+    return buf.readUIntLE(offset, 5);
 }
 module.exports.readUInt40LE = readUInt40LE;
 
-function writeUInt40LE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, 0, 0xffffffffff);
-        assert.ok(offset + 5 <= buf.length, "attempt to write beyond end of buffer");
-    }
-
-    buf.writeInt32LE(val & -1, offset, noAssert);
-    buf.writeUInt8(Math.floor(val * SHIFT_RIGHT_32), offset + 4, noAssert);
+function writeUInt40LE(buf, val, offset) {
+    buf.writeUInt8(val, offset, 5);
 }
 module.exports.writeUInt40LE = writeUInt40LE;
 
-function readUInt48LE(buf, offset, noAssert) {
-    return buf.readUInt16LE(offset + 4, noAssert) * SHIFT_LEFT_32 + buf.readUInt32LE(offset, noAssert);
+function readUInt48LE(buf, offset) {
+    return buf.readUIntLE(offset, 5);
 }
 module.exports.readUInt48LE = readUInt48LE;
 
-function writeUInt48LE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, 0, 0xffffffffffff);
-        assert.ok(offset + 6 <= buf.length, "attempt to write beyond end of buffer");
-    }
-
-    buf.writeInt32LE(val & -1, offset, noAssert);
-    buf.writeUInt16LE(Math.floor(val * SHIFT_RIGHT_32), offset + 4, noAssert);
+function writeUInt48LE(buf, val, offset) {
+    buf.writeUInt16LE(val, offset, 6);
 }
 module.exports.writeUInt48LE = writeUInt48LE;
 
-function readUInt56LE(buf, offset, noAssert) {
-    return ((buf.readUInt8(offset + 6, noAssert) || 0) << 16 | buf.readUInt16LE(offset + 4, noAssert)) * SHIFT_LEFT_32 + buf.readUInt32LE(offset, noAssert);
+function readUInt56LE(buf, offset) {
+    return ((buf.readUInt8(offset + 6) || 0) << 16 | buf.readUInt16LE(offset + 4)) * SHIFT_LEFT_32 + buf.readUInt32LE(offset);
 }
 module.exports.readUInt56LE = readUInt56LE;
 
-function writeUInt56LE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, 0, 0xffffffffffffff);
-        assert.ok(offset + 7 <= buf.length, "attempt to write beyond end of buffer");
-    }
+function writeUInt56LE(buf, val, offset) {
+    check_int(val, 0, 0xffffffffffffff);
+    assert.ok(offset + 7 <= buf.length, "attempt to write beyond end of buffer");
 
     if (val < 0x100000000000000) {
-        buf.writeInt32LE(val & -1, offset, noAssert);
+        buf.writeInt32LE(val & -1, offset);
         var hi = Math.floor(val * SHIFT_RIGHT_32);
-        buf.writeUInt16LE(hi & 0xffff, offset + 4, noAssert);
-        buf.writeUInt8(hi >>> 16, offset + 6, noAssert);
+        buf.writeUInt16LE(hi & 0xffff, offset + 4);
+        buf.writeUInt8(hi >>> 16, offset + 6);
     } else {
         // Special case because 2^56-1 gets rounded up to 2^56
         buf[offset] = 0xff;
@@ -232,20 +186,18 @@ function writeUInt56LE(buf, val, offset, noAssert) {
 }
 module.exports.writeUInt56LE = writeUInt56LE;
 
-function readUInt64LE(buf, offset, noAssert) {
-    return buf.readUInt32LE(offset + 4, noAssert) * SHIFT_LEFT_32 + buf.readUInt32LE(offset, noAssert);
+function readUInt64LE(buf, offset) {
+    return buf.readUInt32LE(offset + 4) * SHIFT_LEFT_32 + buf.readUInt32LE(offset);
 }
 module.exports.readUInt64LE = readUInt64LE;
 
-function writeUInt64LE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, 0, 0xffffffffffffffff);
-        assert.ok(offset + 8 <= buf.length, "attempt to write beyond end of buffer");
-    }
+function writeUInt64LE(buf, val, offset) {
+    check_int(val, 0, 0xffffffffffffffff);
+    assert.ok(offset + 8 <= buf.length, "attempt to write beyond end of buffer");
 
     if (val < 0x10000000000000000) {
-        buf.writeInt32LE(val & -1, offset, noAssert);
-        buf.writeUInt32LE(Math.floor(val * SHIFT_RIGHT_32), offset + 4, noAssert);
+        buf.writeInt32LE(val & -1, offset);
+        buf.writeUInt32LE(Math.floor(val * SHIFT_RIGHT_32), offset + 4);
     } else {
         // Special case because 2^64-1 gets rounded up to 2^64
         buf[offset] = 0xff;
@@ -261,70 +213,50 @@ function writeUInt64LE(buf, val, offset, noAssert) {
 module.exports.writeUInt64LE = writeUInt64LE;
 
 
-function readInt24BE(buf, offset, noAssert) {
-    return (buf.readInt8(offset, noAssert) << 16) + buf.readUInt16BE(offset + 1, noAssert);
+function readInt24BE(buf, offset) {
+    return buf.readIntBE(offset, 3);
 }
 module.exports.readInt24BE = readInt24BE;
 
-function writeInt24BE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, -0x800000, 0x7fffff);
-        assert.ok(offset + 3 <= buf.length, "attempt to write beyond end of buffer");
-    }
-
-    buf.writeInt8(val >> 16, offset, noAssert);
-    buf.writeUInt16BE(val & 0xffff, offset + 1, noAssert);
+function writeInt24BE(buf, val, offset) {
+    buf.writeUIntBE(val, offset, 3);
 }
 module.exports.writeInt24BE = writeInt24BE;
 
-function readInt40BE(buf, offset, noAssert) {
-    return (buf.readInt8(offset, noAssert) || 0) * SHIFT_LEFT_32 + buf.readUInt32BE(offset + 1, noAssert);
+function readInt40BE(buf, offset) {
+    return buf.readIntBE(offset, 5);
 }
 module.exports.readInt40BE = readInt40BE;
 
-function writeInt40BE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, -0x8000000000, 0x7fffffffff);
-        assert.ok(offset + 5 <= buf.length, "attempt to write beyond end of buffer");
-    }
-
-    buf.writeInt8(Math.floor(val * SHIFT_RIGHT_32), offset, noAssert);
-    buf.writeInt32BE(val & -1, offset + 1, noAssert);
+function writeInt40BE(buf, val, offset) {
+    buf.writeIntBE(val, offset, 5);
 }
 module.exports.writeInt40BE = writeInt40BE;
 
-function readInt48BE(buf, offset, noAssert) {
-    return buf.readInt16BE(offset, noAssert) * SHIFT_LEFT_32 + buf.readUInt32BE(offset + 2, noAssert);
+function readInt48BE(buf, offset) {
+    return buf.readIntBE(offset, 6);
 }
 module.exports.readInt48BE = readInt48BE;
 
-function writeInt48BE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, -0x800000000000, 0x7fffffffffff);
-        assert.ok(offset + 6 <= buf.length, "attempt to write beyond end of buffer");
-    }
-
-    buf.writeInt16BE(Math.floor(val * SHIFT_RIGHT_32), offset, noAssert);
-    buf.writeInt32BE(val & -1, offset + 2, noAssert);
+function writeInt48BE(buf, val, offset) {
+    buf.writeIntBE(val, offset, 6);
 }
 module.exports.writeInt48BE = writeInt48BE;
 
-function readInt56BE(buf, offset, noAssert) {
-    return (((buf.readInt8(offset, noAssert) || 0) << 16) + buf.readUInt16BE(offset + 1, noAssert)) * SHIFT_LEFT_32 + buf.readUInt32BE(offset + 3, noAssert);
+function readInt56BE(buf, offset) {
+    return (((buf.readInt8(offset) || 0) << 16) + buf.readUInt16BE(offset + 1)) * SHIFT_LEFT_32 + buf.readUInt32BE(offset + 3);
 }
 module.exports.readInt56BE = readInt56BE;
 
-function writeInt56BE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, -0x800000000000000, 0x7fffffffffffff);
-        assert.ok(offset + 7 <= buf.length, "attempt to write beyond end of buffer");
-    }
+function writeInt56BE(buf, val, offset) {
+    check_int(val, -0x800000000000000, 0x7fffffffffffff);
+    assert.ok(offset + 7 <= buf.length, "attempt to write beyond end of buffer");
 
     if (val < 0x80000000000000) {
         var hi = Math.floor(val * SHIFT_RIGHT_32);
-        buf.writeInt8(hi >> 16, offset, noAssert);
-        buf.writeUInt16BE(hi & 0xffff, offset + 1, noAssert);
-        buf.writeInt32BE(val & -1, offset + 3, noAssert);
+        buf.writeInt8(hi >> 16, offset);
+        buf.writeUInt16BE(hi & 0xffff, offset + 1);
+        buf.writeInt32BE(val & -1, offset + 3);
     } else {
         // Special case because 2^55-1 gets rounded up to 2^55
         buf[offset] = 0x7f;
@@ -338,20 +270,18 @@ function writeInt56BE(buf, val, offset, noAssert) {
 }
 module.exports.writeInt56BE = writeInt56BE;
 
-function readInt64BE(buf, offset, noAssert) {
-    return buf.readInt32BE(offset, noAssert) * SHIFT_LEFT_32 + buf.readUInt32BE(offset + 4, noAssert);
+function readInt64BE(buf, offset) {
+    return buf.readInt32BE(offset) * SHIFT_LEFT_32 + buf.readUInt32BE(offset + 4);
 }
 module.exports.readInt64BE = readInt64BE;
 
-function writeInt64BE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, -0x800000000000000000, 0x7fffffffffffffff);
-        assert.ok(offset + 8 <= buf.length, "attempt to write beyond end of buffer");
-    }
+function writeInt64BE(buf, val, offset) {
+    check_int(val, -0x800000000000000000, 0x7fffffffffffffff);
+    assert.ok(offset + 8 <= buf.length, "attempt to write beyond end of buffer");
 
     if (val < 0x8000000000000000) {
-        buf.writeInt32BE(Math.floor(val * SHIFT_RIGHT_32), offset, noAssert);
-        buf.writeInt32BE(val & -1, offset + 4, noAssert);
+        buf.writeInt32BE(Math.floor(val * SHIFT_RIGHT_32), offset);
+        buf.writeInt32BE(val & -1, offset + 4);
     } else {
         // Special case because 2^63-1 gets rounded up to 2^63
         buf[offset] = 0x7f;
@@ -366,70 +296,50 @@ function writeInt64BE(buf, val, offset, noAssert) {
 }
 module.exports.writeInt64BE = writeInt64BE;
 
-function readInt24LE(buf, offset, noAssert) {
-    return (buf.readInt8(offset + 2, noAssert) << 16) + buf.readUInt16LE(offset, noAssert);
+function readInt24LE(buf, offset) {
+    return buf.readIntLE(offset, 3);
 }
 module.exports.readInt24LE = readInt24LE;
 
-function writeInt24LE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, -0x800000, 0x7fffff);
-        assert.ok(offset + 3 <= buf.length, "attempt to write beyond end of buffer");
-    }
-
-    buf.writeUInt16LE(val & 0xffff, offset, noAssert);
-    buf.writeInt8(val >> 16, offset + 2, noAssert);
+function writeInt24LE(buf, val, offset) {
+    buf.writeIntLE(val, offset, 3);
 }
 module.exports.writeInt24LE = writeInt24LE;
 
-function readInt40LE(buf, offset, noAssert) {
-    return (buf.readInt8(offset + 4, noAssert) || 0) * SHIFT_LEFT_32 + buf.readUInt32LE(offset, noAssert);
+function readInt40LE(buf, offset) {
+    return buf.readIntLE(offset, 5);
 }
 module.exports.readInt40LE = readInt40LE;
 
-function writeInt40LE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, -0x8000000000, 0x7fffffffff);
-        assert.ok(offset + 5 <= buf.length, "attempt to write beyond end of buffer");
-    }
-
-    buf.writeInt32LE(val & -1, offset, noAssert);
-    buf.writeInt8(Math.floor(val * SHIFT_RIGHT_32), offset + 4, noAssert);
+function writeInt40LE(buf, val, offset) {
+    buf.writeIntLE(val, offset, 5);
 }
 module.exports.writeInt40LE = writeInt40LE;
 
-function readInt48LE(buf, offset, noAssert) {
-    return buf.readInt16LE(offset + 4, noAssert) * SHIFT_LEFT_32 + buf.readUInt32LE(offset, noAssert);
+function readInt48LE(buf, offset) {
+    return buf.readIntLE(offset, 6);
 }
 module.exports.readInt48LE = readInt48LE;
 
-function writeInt48LE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, -0x800000000000, 0x7fffffffffff);
-        assert.ok(offset + 6 <= buf.length, "attempt to write beyond end of buffer");
-    }
-
-    buf.writeInt32LE(val & -1, offset, noAssert);
-    buf.writeInt16LE(Math.floor(val * SHIFT_RIGHT_32), offset + 4, noAssert);
+function writeInt48LE(buf, val, offset) {
+    buf.writeIntLE(val, offset, 6);
 }
 module.exports.writeInt48LE = writeInt48LE;
 
-function readInt56LE(buf, offset, noAssert) {
-    return (((buf.readInt8(offset + 6, noAssert) || 0) << 16) + buf.readUInt16LE(offset + 4, noAssert)) * SHIFT_LEFT_32 + buf.readUInt32LE(offset, noAssert);
+function readInt56LE(buf, offset) {
+    return (((buf.readInt8(offset + 6) || 0) << 16) + buf.readUInt16LE(offset + 4)) * SHIFT_LEFT_32 + buf.readUInt32LE(offset);
 }
 module.exports.readInt56LE = readInt56LE;
 
-function writeInt56LE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, -0x80000000000000, 0x7fffffffffffff);
-        assert.ok(offset + 7 <= buf.length, "attempt to write beyond end of buffer");
-    }
+function writeInt56LE(buf, val, offset) {
+    check_int(val, -0x80000000000000, 0x7fffffffffffff);
+    assert.ok(offset + 7 <= buf.length, "attempt to write beyond end of buffer");
 
     if (val < 0x80000000000000) {
-        buf.writeInt32LE(val & -1, offset, noAssert);
+        buf.writeInt32LE(val & -1, offset);
         var hi = Math.floor(val * SHIFT_RIGHT_32);
-        buf.writeUInt16LE(hi & 0xffff, offset + 4, noAssert);
-        buf.writeInt8(hi >> 16, offset + 6, noAssert);
+        buf.writeUInt16LE(hi & 0xffff, offset + 4);
+        buf.writeInt8(hi >> 16, offset + 6);
     } else {
         // Special case because 2^55-1 gets rounded up to 2^55
         buf[offset] = 0xff;
@@ -443,20 +353,18 @@ function writeInt56LE(buf, val, offset, noAssert) {
 }
 module.exports.writeInt56LE = writeInt56LE;
 
-function readInt64LE(buf, offset, noAssert) {
-    return buf.readInt32LE(offset + 4, noAssert) * SHIFT_LEFT_32 + buf.readUInt32LE(offset, noAssert);
+function readInt64LE(buf, offset) {
+    return buf.readInt32LE(offset + 4) * SHIFT_LEFT_32 + buf.readUInt32LE(offset);
 }
 module.exports.readInt64LE = readInt64LE;
 
-function writeInt64LE(buf, val, offset, noAssert) {
-    if (!noAssert) {
-        check_int(val, -0x8000000000000000, 0x7fffffffffffffff);
-        assert.ok(offset + 8 <= buf.length, "attempt to write beyond end of buffer");
-    }
+function writeInt64LE(buf, val, offset) {
+    check_int(val, -0x8000000000000000, 0x7fffffffffffffff);
+    assert.ok(offset + 8 <= buf.length, "attempt to write beyond end of buffer");
 
     if (val < 0x8000000000000000) {
-        buf.writeInt32LE(val & -1, offset, noAssert);
-        buf.writeInt32LE(Math.floor(val * SHIFT_RIGHT_32), offset + 4, noAssert);
+        buf.writeInt32LE(val & -1, offset);
+        buf.writeInt32LE(Math.floor(val * SHIFT_RIGHT_32), offset + 4);
     } else {
         // Special case because 2^55-1 gets rounded up to 2^55
         buf[offset] = 0xff;

--- a/polyfill.js
+++ b/polyfill.js
@@ -10,13 +10,13 @@ Buffer.assertContiguousInt = bmi.assertContiguousInt;
         ['BE', 'LE'].forEach(function (endian) {
             var read = 'read' + signed + size + endian;
             var reader = bmi[read];
-            Buffer.prototype[read] = function(offset, noAssert) {
-                return reader(this, offset, noAssert);
+            Buffer.prototype[read] = function(offset) {
+                return reader(this, offset);
             };
             var write = 'write' + signed + size + endian;
             var writer = bmi[write];
-            Buffer.prototype[write] = function(val, offset, noAssert) {
-                writer(this, val, offset, noAssert);
+            Buffer.prototype[write] = function(val, offset) {
+                writer(this, val, offset);
             };
         });
     });
@@ -26,11 +26,11 @@ Buffer.assertContiguousInt = bmi.assertContiguousInt;
 // outside of the buffer, unlike for other widths.  These functions
 // make it consistent with the others.
 var consistent_readX8 = {
-    readUInt8: function (offset, noAssert) {
-        return this.readUInt8(offset, noAssert) || 0;
+    readUInt8: function (offset) {
+        return this.readUInt8(offset) || 0;
     },
-    readInt8: function (offset, noAssert) {
-        return this.readInt8(offset, noAssert) || 0;
+    readInt8: function (offset) {
+        return this.readInt8(offset) || 0;
     }
 };
 
@@ -43,19 +43,19 @@ function make_accessor(read, prefix, suffix) {
     }
 
     if (read) {
-        Buffer.prototype[prefix + suffix] = function (len, offset, noAssert) {
+        Buffer.prototype[prefix + suffix] = function (len, offset) {
             var reader = accessors[len];
             if (reader) {
-                return reader.call(this, offset, noAssert);
+                return reader.call(this, offset);
             } else {
                 throw new Error("Cannot read integer of length " + len);
             }
         };
     } else {
-        Buffer.prototype[prefix + suffix] = function (len, val, offset, noAssert) {
+        Buffer.prototype[prefix + suffix] = function (len, val, offset) {
             var writer = accessors[len];
             if (writer) {
-                return writer.call(this, val, offset, noAssert);
+                return writer.call(this, val, offset);
             } else {
                 throw new Error("Cannot write integer of length " + len);
             }


### PR DESCRIPTION
The support for the `noAssert` argument dropped in the upcoming
Node.js 10.x release. This removes the argument therefore.

This should also be a performance boost for all functions besides the 56 and 64 bit functions.

Refs: https://github.com/nodejs/node/pull/18395

I was not able to get all tests to pass though. So please have a close look!