### PR TITLE
define Buffer for amqplib support with react native

### DIFF
--- a/buffer-more-ints.js
+++ b/buffer-more-ints.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Buffer = require('safe-buffer').Buffer;
+
 // JavaScript is numerically challenged
 var SHIFT_LEFT_32 = (1 << 16) * (1 << 16);
 var SHIFT_RIGHT_32 = 1 / SHIFT_LEFT_32;


### PR DESCRIPTION
I'm using `amqplib` with `react-native`

I ran into an error where `metro bundler` couldn't find the variable `Buffer` and pointed to `buffer-more-ints.js`

I tried creating shim files and globally declaring `Buffer` in my own project to no avail. I was able to resolve the issue by defining `Buffer` within `buffer-more-ints.js` itself

So that is my pr: to explicitly define `Buffer` for supporting `amqplib` usage in `react-native`

I ran all the tests and they passed. 